### PR TITLE
Add multipart to image

### DIFF
--- a/turbo_art.py
+++ b/turbo_art.py
@@ -34,6 +34,7 @@ inference_image = (
         "transformers~=4.35",
         "accelerate~=0.25",
         "safetensors~=0.4",
+        "python-multipart==0.0.9",
     )
     .run_function(download_models)
 )


### PR DESCRIPTION
This was part of the old modal container requirements but removed from the 2024.04 image builder candidate. It's needed by some fastapi workflows.