### PR TITLE
stub -> app

### DIFF
--- a/turbo_art.py
+++ b/turbo_art.py
@@ -2,27 +2,9 @@ from pathlib import Path
 
 from fastapi import FastAPI, File, Form, Response, UploadFile
 from fastapi.staticfiles import StaticFiles
-from modal import Image, Mount, Stub, asgi_app, gpu, web_endpoint
+from modal import Image, Mount, App, asgi_app, build, enter, gpu, web_endpoint
 
-
-def download_models():
-    from huggingface_hub import snapshot_download
-
-    # Ignore files that we don't need to speed up download time.
-    ignore = [
-        "*.bin",
-        "*.onnx_data",
-        "*/diffusion_pytorch_model.safetensors",
-    ]
-
-    snapshot_download("stabilityai/sdxl-turbo", ignore_patterns=ignore)
-
-    # https://huggingface.co/docs/diffusers/main/en/using-diffusers/sdxl_turbo#speed-up-sdxl-turbo-even-more
-    # vae is used for a inference speedup
-    snapshot_download("madebyollin/sdxl-vae-fp16-fix", ignore_patterns=ignore)
-
-
-stub = Stub("stable-diffusion-xl-turbo")
+app = App("stable-diffusion-xl-turbo")
 
 web_image = Image.debian_slim().pip_install("jinja2")
 
@@ -35,7 +17,6 @@ inference_image = (
         "accelerate~=0.25",
         "safetensors~=0.4",
     )
-    .run_function(download_models)
 )
 
 with inference_image.imports():
@@ -47,14 +28,32 @@ with inference_image.imports():
     from PIL import Image
 
 
-@stub.cls(
+@app.cls(
     gpu="A100",
     image=inference_image,
     container_idle_timeout=240,
     concurrency_limit=10,
 )
 class Model:
-    def __enter__(self):
+    @build()
+    def build(self):
+        from huggingface_hub import snapshot_download
+
+        # Ignore files that we don't need to speed up download time.
+        ignore = [
+            "*.bin",
+            "*.onnx_data",
+            "*/diffusion_pytorch_model.safetensors",
+        ]
+
+        snapshot_download("stabilityai/sdxl-turbo", ignore_patterns=ignore)
+
+        # https://huggingface.co/docs/diffusers/main/en/using-diffusers/sdxl_turbo#speed-up-sdxl-turbo-even-more
+        # vae is used for a inference speedup
+        snapshot_download("madebyollin/sdxl-vae-fp16-fix", ignore_patterns=ignore)
+
+    @enter()
+    def enter(self):
         self.pipe = AutoPipelineForImage2Image.from_pretrained(
             "stabilityai/sdxl-turbo",
             torch_dtype=torch.float16,
@@ -115,7 +114,7 @@ base_path = Path(__file__).parent
 static_path = base_path.joinpath("frontend", "dist")
 
 
-@stub.function(
+@app.function(
     mounts=[Mount.from_local_dir(static_path, remote_path="/assets")],
     image=web_image,
     allow_concurrent_inputs=10,


### PR DESCRIPTION
Also updated `__enter__` to `@enter` and taking advantage of `@build`

The app seems broken though, with this issue:

```
ValueError: No web_url can be found for function None. web_url can only be referenced from a running app context
```

I think this error is because we run `asgi_app` before hydration (I believe it's a known bug)